### PR TITLE
Removed broad exception clause to catch exceptions which may be relevant...

### DIFF
--- a/redlock/__init__.py
+++ b/redlock/__init__.py
@@ -36,10 +36,12 @@ class Redlock(object):
         self.retry_delay = retry_delay or self.default_retry_delay
 
     def lock_instance(self, server, resource, val, ttl):
-        try:
-            return server.set(resource, val, nx=True, px=ttl)
-        except:
-            return False
+        """
+        The redis-py SET command returns True if lock is acquired and None if not.
+        :rtype: True | False
+        :returns: True if lock is acquired, False otherwise.
+        """
+        return server.set(resource, val, nx=True, px=ttl) or False
 
     def unlock_instance(self, server, resource, val):
         try:


### PR DESCRIPTION
NB: I only briefly acquainted myself with the algorithm.  I'm not entirely sure this doesn't sabotage the nature of the algorithm (since it requires precise timing), but it's a lot easier to debug exceptions than to figure out why a lock isn't being acquired due to a broad catch clause.

For example, a ResponseError indicating the wrong number of arguments is
raised when the Redis server version is too old to handle the `nx` or `px`
arguments. This exception information is useful, and the case of acquiring
or not acquiring the lock can be handled by expecting either True or None
from the call to `set`.