### PR TITLE
quorum majority: num servers actually up vs num servers client thinks are up

### DIFF
--- a/redlock/__init__.py
+++ b/redlock/__init__.py
@@ -8,6 +8,10 @@ from collections import namedtuple
 Lock = namedtuple("Lock", ("validity", "resource", "key"))
 
 
+class CannotObtainLock(Exception):
+    pass
+
+
 class Redlock(object):
 
     default_retry_count = 3
@@ -31,7 +35,11 @@ class Redlock(object):
                 self.servers.append(server)
             except Exception as e:
                 raise Warning(str(e))
-        self.quorum = (len(self.servers) / 2) + 1
+        self.quorum = (len(self.connection_list) / 2) + 1
+
+        if len(self.servers) < self.quorum:
+            raise CannotObtainLock(
+                "Failed to connect to the majority of redis servers")
         self.retry_count = retry_count or self.default_retry_count
         self.retry_delay = retry_delay or self.default_retry_delay
 


### PR DESCRIPTION
I may be confused here, so please correct me if I'm wrong.

```
-        self.quorum = (len(self.servers) / 2) + 1
+        self.quorum = (len(self.connection_list) / 2) + 1
```

I was under the impression that the client's calculation for cluster majority should be based on the number of redis servers in the cluster (or expected to be in the cluster), rather than the number of servers the client thinks are in the cluster.  

Example:
There are 5 redis servers in the cluster.  Two Redlock clients initialize.  Due to a network partition, client1 only connects to 3 servers.  Client2 connects to all 5 servers.  In this case, we have:

```
client1_quorum = 3 / 2 +1 = 2
client2_quorum = 5 / 1 + 1 = 3
```

Let's say client1 and client2 both decide to compete for the same lock at the same time.  In this case, client1 could lock on 2 of 5 servers, and client2 could lock on the remaining 3 of 5 servers.  Both clients would believe they had majority, and both would obtain the same lock.  Am I incorrect?

---
Continuing with this, the Redis distributed lock documentation says, 

```
Liveness property B: Fault tolerance. As long as the majority of Redis nodes are up, clients are able to acquire and release locks.
```

The proposed change would make it so that client1 would still be able to obtain quorum for a lock, though if it ever competes with client2, I believe client2 has the greater chance of winning the lock.

Secondly, if client1 cannot connect to more than (n/2+1) redis servers, it should raise an exception because it will never be able to obtain a lock.