### PR TITLE
Use setex command with older versions of redis

### DIFF
--- a/redlock/__init__.py
+++ b/redlock/__init__.py
@@ -55,6 +55,13 @@ class Redlock(object):
     def lock_instance(self, server, resource, val, ttl):
         try:
             return server.set(resource, val, nx=True, px=ttl)
+        except redis.exceptions.ResponseError:
+            try:
+                if server.get(resource):
+                    return False
+                return server.setex(resource, ttl, val)
+            except:
+                return False
         except:
             return False
 


### PR DESCRIPTION
My team's development environment is stuck with Redis 2.2 for now. 2.2 doesn't support the extended `nx` and `px` arguments for `set`, which came along in Redis 2.6. This PR tries using `setex` as a fallback if the server doesn't recognize those extra args. It will allow me to use redlock-py in development until we all get with the Redis 2.6+ program. Others in the same boat as me may find it useful as well.