### PR TITLE
Issue-1: Raise `ValueError` and `MultipleRedlockException` when appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 redlock_py.egg-info
 dist
 __pycache__
+.cache

--- a/README.md
+++ b/README.md
@@ -10,14 +10,10 @@ To create a lock manager:
 
 To acquire a lock:
 
-    my_lock, errors = dlm.lock("my_resource_name",1000)
+    my_lock = dlm.lock("my_resource_name",1000)
 
 Where the resource name is an unique identifier of what you are trying to lock
-and 1000 is the number of milliseconds for the validity time. The second return
-value errors is list of `redis-py.exceptions.RedisError` objects, each of which
-corresponds to an exception raised when interacting with a redis master. If it's
-an empty list, then there is no error. If it's not empty, then there is a problem when
-communicating with some redis masters.
+and 1000 is the number of milliseconds for the validity time.
 
 The returned value is `False` if the lock was not acquired (you may try again),
 otherwise an namedtuple representing the lock is returned, having three fields:
@@ -34,10 +30,9 @@ It is possible to setup the number of retries (by default 3) and the retry
 delay (by default 200 milliseconds) used to acquire the lock.
 
 
-In both `dlm.lock` and `dlm.unlock` calls, a `MultipleRedlockException` object will be raised
-if there are errors when communicating with one or more redis masters. The caller of `dlm`
-should use a try-catch-finally block to handle this exception. A `MultipleRedlockException`
-object encapsulates multiple `redis-py.exceptions.RedisError` objects.
+Both `dlm.lock` and `dlm.unlock` raise a exception `MultipleRedlockException` if there are errors when communicating with one or more redis masters. The caller of `dlm` should
+use a try-catch-finally block to handle this exception. A `MultipleRedlockException` object
+encapsulates multiple `redis-py.exceptions.RedisError` objects.
 
 
 **Disclaimer**: This code implements an algorithm which is currently a proposal, it was not formally analyzed. Make sure to understand how it works before using it in your production environments.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ To create a lock manager:
 
 To acquire a lock:
 
-    my_lock = dlm.lock("my_resource_name",1000)
+    my_lock, errors = dlm.lock("my_resource_name",1000)
 
 Where the resource name is an unique identifier of what you are trying to lock
-and 1000 is the number of milliseconds for the validity time.
+and 1000 is the number of milliseconds for the validity time. The second return
+value errors is list of `redis-py.exceptions.RedisError` objects, each of which
+corresponds to an exception raised when interacting with a redis master. If it's
+an empty list, then there is no error. If it's not empty, then there is a problem when
+communicating with some redis masters.
 
 The returned value is `False` if the lock was not acquired (you may try again),
 otherwise an namedtuple representing the lock is returned, having three fields:
@@ -27,7 +31,13 @@ To release a lock:
     dlm.unlock(my_lock)
 
 It is possible to setup the number of retries (by default 3) and the retry
-delay (by default 200 milliseconds) used to acquire the lock. 
+delay (by default 200 milliseconds) used to acquire the lock.
+
+
+In both `dlm.lock` and `dlm.unlock` calls, a `MultipleRedlockException` object will be raised
+if there are errors when communicating with one or more redis masters. The caller of `dlm`
+should use a try-catch-finally block to handle this exception. A `MultipleRedlockException`
+object encapsulates multiple `redis-py.exceptions.RedisError` objects.
 
 
 **Disclaimer**: This code implements an algorithm which is currently a proposal, it was not formally analyzed. Make sure to understand how it works before using it in your production environments.

--- a/redlock/__init__.py
+++ b/redlock/__init__.py
@@ -92,7 +92,7 @@ class Redlock(object):
         while retry < self.retry_count:
             n = 0
             start_time = int(time.time() * 1000)
-            redis_errors.clear()
+            del redis_errors[:]
             for server in self.servers:
                 try:
                     if self.lock_instance(server, resource, val, ttl):

--- a/tests/test_redlock.py
+++ b/tests/test_redlock.py
@@ -1,6 +1,6 @@
 import unittest
 
-from redlock import Redlock
+from redlock import Redlock, MultipleRedlockException
 
 
 class TestRedlock(unittest.TestCase):
@@ -30,3 +30,14 @@ class TestRedlock(unittest.TestCase):
         key = self.redlock.servers[0].get("pants")
         self.assertEquals(lock.key, key)
 
+    def test_ttl_not_int_trigger_exception_value_error(self):
+        with self.assertRaises(ValueError):
+            self.redlock.lock("pants", 1000.0)
+
+    def test_multiple_redlock_exception(self):
+        ex1 = Exception("Redis connection error")
+        ex2 = Exception("Redis command timed out")
+        exc = MultipleRedlockException([ex1, ex2])
+        exc_str = str(exc)
+        self.assertIn('connection error', exc_str)
+        self.assertIn('command timed out', exc_str)


### PR DESCRIPTION
The methods `Redlock.lock` and `Redlock.unlock` should raise either a `ValueError` or a `MultipleRedlockException` when communicating with one or several redis masters triggers errors