### PR TITLE
Add the capacity to extend a RedLock lock, as per the specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,22 @@ It is possible to setup the number of retries (by default 3) and the retry
 delay (by default 200 milliseconds) used to acquire the lock.
 
 
-Both `dlm.lock` and `dlm.unlock` raise a exception `MultipleRedlockException` if there are errors when communicating with one or more redis masters. The caller of `dlm` should
+To extend your ownership of a lock that you already own:
+
+    dlm.extend(my_lock,ttl)
+    
+where you want to extend the liftime of the lock by `ttl` milliseconds.  This returns
+`True` if the extension succeeded and `False` if the lock had already expired.
+
+To test whether a lock is taken:
+
+	dlm.test("lock_name")
+	
+returns `True` if it is taken and `False` if it is free.
+
+
+
+`dlm.lock`, `dlm.unlock`, `dlm.extend` and `dlt.test` raise a exception `MultipleRedlockException` if there are errors when communicating with one or more redis masters. The caller of `dlm` should
 use a try-catch-finally block to handle this exception. A `MultipleRedlockException` object
 encapsulates multiple `redis-py.exceptions.RedisError` objects.
 

--- a/redlock/__init__.py
+++ b/redlock/__init__.py
@@ -162,8 +162,9 @@ class Redlock(object):
             raise MultipleRedlockException(redis_errors)
         return n>=self.quorum
         
-    def test(self,lock):
+    def test(self,name):
         redis_errors = []
+        lock=Lock(0,name,None)
         n=0
         for server in self.servers:
             try:

--- a/redlock/cli.py
+++ b/redlock/cli.py
@@ -72,8 +72,7 @@ def extend(name, validity, key, redis, **kwargs):
 def test(name,redis,**kwargs):
     try:
         dlm = redlock.Redlock(redis)
-        lock = redlock.Lock(0,name,None)
-        if dlm.test(lock):
+        if dlm.test(name):
             print("Lock {} taken".format(name))
         else:
             print("Lock {} available".format(name))

--- a/redlock/cli.py
+++ b/redlock/cli.py
@@ -54,6 +54,20 @@ def unlock(name, key, redis, **kwargs):
     log("ok")
     return 0
 
+def extend(name, validity, key, redis, **kwargs):
+    try:
+        dlm = redlock.Redlock(redis)
+        lock = redlock.Lock(0, name, key)
+        dlm.extend(lock, validity)
+    except Exception as e:
+        log("Error: %s" % e)
+        return 3
+
+    log("ok")
+    return 0
+
+
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -83,7 +97,13 @@ def main():
     parser_unlock.set_defaults(func=unlock)
     parser_unlock.add_argument("name", help="Lock resource name")
     parser_unlock.add_argument("key", help="Result returned by a prior 'lock' command")
-
+    
+    parser_extend = subparsers.add_parser('extend', help='Extend a lock')
+    parser_extend.set_defaults(func=extend)
+    parser_extend.add_argument("name", help="Lock resource name")
+    parser_extend.add_argument("key", help="Result returned by a prior 'lock' command")
+    parser_extend.add_argument("validity", type=int, help="Number of milliseconds the lock's validity will be extended by.")
+    
     args = parser.parse_args()
     log.quiet = args.quiet
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,19 @@ To release a lock:
 It is possible to setup the number of retries (by default 3) and the retry
 delay (by default 200 milliseconds) used to acquire the lock.
 
+To extend your ownership of a lock that you already own:
+
+    dlm.extend(my_lock,ttl)
+    
+where you want to extend the liftime of the lock by `ttl` milliseconds.  This returns
+`True` if the extension succeeded and `False` if the lock had already expired.
+
+To test whether a lock is taken:
+
+    dlm.test("lock_name")
+    
+returns `True` if it is taken and `False` if it is free.
+
 
 **Disclaimer**: This code implements an algorithm which is currently a proposal,
 it was not formally analyzed. Make sure to understand how it works before using it


### PR DESCRIPTION
I have added some small changes top the base class that allow:
(1) use of an extend method to extend a lock that is already owner by a specified ttl
(2) test if a lock with a given name is already taken
The extension mechanism is based on the specification in the original paper, and uses an in-DB Lua script to ensure atomicity.  
I have also updated the CLI accordingly. 
This is a small change, but adds a useful capability, enabling lock owners to poll and extend at regular intervals.  I hope you think it adds to the library as is.